### PR TITLE
first release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.data.scraping
 Title: Scrapes data from various web sources needed for PACTA
-Version: 0.0.1.9000
+Version: 0.0.2
 Authors@R: 
     c(person(given = "CJ",
              family = "Yetman",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
 # pacta.data.scraping 0.0.2
 
-# pacta.data.scraping 0.0.1.9000
-
 * Added a `NEWS.md` file to track changes to the package.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,5 @@
+# pacta.data.scraping 0.0.2
+
+# pacta.data.scraping 0.0.1.9000
+
+* Added a `NEWS.md` file to track changes to the package.


### PR DESCRIPTION
I think this package actually was created with version 0.0.1.9000 (rather than 0.0.0.9000), so "first release" will now correspond to `0.0.2`. 

- Increment version number to 0.0.2
- Added a `NEWS.md` file to track changes
