### PR TITLE
Adapt index scraper to new MSCI layout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,8 @@ Imports:
     rvest,
     stats,
     tibble,
-    tidyr
+    tidyr,
+    stringr
 Depends: 
     R (>= 3.4.0)
 LazyData: true

--- a/R/get_index_regions.R
+++ b/R/get_index_regions.R
@@ -11,18 +11,7 @@ get_index_regions <- function() {
 
   dev_url <- "https://www.msci.com/our-solutions/indexes/developed-markets"
 
-  # start the headless browser and capture the DOM as HTML after JavaScript runs
-  session <- chromote::ChromoteSession$new()
-  session$Network$setUserAgentOverride(userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15")
-
-  { # these commands must be run together, hence the {...}
-    session$Page$navigate(dev_url, wait_ = FALSE)
-    session$Page$loadEventFired() # wait until the page is loaded to continue
-  }
-
-  html <- session$Runtime$evaluate("document.documentElement.outerHTML")$result$value
-
-  session$close() # close the headless browser session
+  html <- fetch_url_html(dev_url)
 
   dev_countries <-
     html %>%
@@ -38,18 +27,7 @@ get_index_regions <- function() {
 
   em_url <- "https://www.msci.com/our-solutions/indexes/emerging-markets"
 
-  # start the headless browser and capture the DOM as HTML after JavaScript runs
-  session <- chromote::ChromoteSession$new()
-  session$Network$setUserAgentOverride(userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15")
-
-  { # these commands must be run together, hence the {...}
-    session$Page$navigate(em_url, wait_ = FALSE)
-    session$Page$loadEventFired() # wait until the page is loaded to continue
-  }
-
-  html <- session$Runtime$evaluate("document.documentElement.outerHTML")$result$value
-
-  session$close() # close the headless browser session
+  html <- fetch_url_html(em_url)
 
   em_countries <-
     html %>%
@@ -78,4 +56,22 @@ get_index_regions <- function() {
   dplyr::mutate(country_iso = countryname(.data$country, "iso2c")) %>%
   dplyr::distinct() %>%
   dplyr::arrange("equity_market", "country", "country_iso")
+}
+
+fetch_url_html <- function(url) {
+
+  # start the headless browser and capture the DOM as HTML after JavaScript runs
+  session <- chromote::ChromoteSession$new()
+  session$Network$setUserAgentOverride(userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15")
+
+  { # these commands must be run together, hence the {...}
+    session$Page$navigate(url, wait_ = FALSE)
+    session$Page$loadEventFired() # wait until the page is loaded to continue
+  }
+
+  html <- session$Runtime$evaluate("document.documentElement.outerHTML")$result$value
+
+  session$close() # close the headless browser session
+
+  return(html)
 }

--- a/R/get_index_regions.R
+++ b/R/get_index_regions.R
@@ -6,6 +6,36 @@
 #' @export
 
 get_index_regions <- function() {
+
+  # developed countries --------------------------------------------------------
+
+  dev_url <- "https://www.msci.com/our-solutions/indexes/developed-markets"
+
+  # start the headless browser and capture the DOM as HTML after JavaScript runs
+  session <- chromote::ChromoteSession$new()
+  session$Network$setUserAgentOverride(userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Safari/605.1.15")
+
+  { # these commands must be run together, hence the {...}
+    session$Page$navigate(dev_url, wait_ = FALSE)
+    session$Page$loadEventFired() # wait until the page is loaded to continue
+  }
+
+  html <- session$Runtime$evaluate("document.documentElement.outerHTML")$result$value
+
+  session$close() # close the headless browser session
+
+  dev_countries <-
+    html %>%
+    rvest::read_html() %>%
+    rvest::html_elements(css = ".cw-table") %>%
+    rvest::html_elements("td:not(.heading2)") %>%
+    rvest::html_text2() %>%
+    stringr::str_trim()
+
+  dev_countries <- dev_countries[dev_countries != ""]
+
+  # emerging countries ---------------------------------------------------------
+
   em_url <- "https://www.msci.com/our-solutions/indexes/emerging-markets"
 
   # start the headless browser and capture the DOM as HTML after JavaScript runs
@@ -21,21 +51,13 @@ get_index_regions <- function() {
 
   session$close() # close the headless browser session
 
-  # developed countries --------------------------------------------------------
-
-  dev_countries <-
-    html %>%
-    rvest::read_html() %>%
-    rvest::html_elements(css = "#boxes-container-1 li") %>%
-    rvest::html_text2()
-
-  # emerging countries ---------------------------------------------------------
-
   em_countries <-
     html %>%
     rvest::read_html() %>%
-    rvest::html_elements(css = "#boxes-container-2 li") %>%
-    rvest::html_text2()
+    rvest::html_elements(css = "#ms136-emi-010523 .index-type-container.index-type-equity") %>%
+    rvest::html_text2() %>%
+    strsplit("\n") %>%
+    unlist()
 
   # error if values are empty --------------------------------------------------
 

--- a/man/pacta.data.scraping-package.Rd
+++ b/man/pacta.data.scraping-package.Rd
@@ -30,7 +30,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item Rocky Mountain Institute \email{PACTA4investors@rmi.org} [copyright holder, funder]
+  \item RMI \email{PACTA4investors@rmi.org} [copyright holder, funder]
 }
 
 }


### PR DESCRIPTION
Closes #18

``` r
library(pacta.data.scraping)

get_index_regions()
#> # A tibble: 95 × 3
#>    equity_market country     country_iso
#>    <chr>         <chr>       <chr>      
#>  1 GlobalMarket  Canada      CA         
#>  2 GlobalMarket  Austria     AT         
#>  3 GlobalMarket  Italy       IT         
#>  4 GlobalMarket  Australia   AU         
#>  5 GlobalMarket  US          US         
#>  6 GlobalMarket  Belgium     BE         
#>  7 GlobalMarket  Netherlands NL         
#>  8 GlobalMarket  Hong Kong   HK         
#>  9 GlobalMarket  Denmark     DK         
#> 10 GlobalMarket  Norway      NO         
#> # ℹ 85 more rows
```

<sup>Created on 2023-06-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>