### PR TITLE
Prefer using `httr2` and `V8` over `chromote`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports: 
     cli (>= 3.5.0),
-    chromote,
     countrycode,
     curl,
     dplyr (>= 1.1.0),
@@ -45,7 +44,8 @@ Imports:
     stats,
     tibble,
     tidyr,
-    stringr
+    stringr,
+    V8
 Depends: 
     R (>= 3.4.0)
 LazyData: true

--- a/R/get_index_regions.R
+++ b/R/get_index_regions.R
@@ -34,7 +34,12 @@ get_index_regions <- function() {
 
   ct <- V8::v8()
   #parse the html content from the js output and print it as text
-  ct$eval(gsub('document.write', '', rvest::html_text2(js_script)))
+    render_script <- str_replace(
+      pattern = 'document.write',
+      replacement = '',
+      string = rvest::html_text2(js_script)
+    )
+    ct$eval(render_script)
 
   data <- jsonlite::parse_json(
     ct$get("JSON.stringify(chartDataEMJson)"),

--- a/R/get_index_regions.R
+++ b/R/get_index_regions.R
@@ -34,7 +34,7 @@ get_index_regions <- function() {
 
   ct <- V8::v8()
   #parse the html content from the js output and print it as text
-    render_script <- str_replace(
+    render_script <- stringr::str_replace(
       pattern = 'document.write',
       replacement = '',
       string = rvest::html_text2(js_script)


### PR DESCRIPTION
This PR does several things...

We were getting timeout and response errors using `chromote` when trying to run `get_index_regions` on the VM. We weren't sure what was going on, but it seemed to be an issue with waiting for `loadEventFired()`. 

@AlexAxthelm suggested we try to not depend on `chromote` in general, because it's a bit bulky and probably overkill for our purposes. 

To that end, I tried to replace the `chromote` implementation with a more lightweight `httr2` implementation, and scrape all of the data using standard HTTP requests. This posed an issue as well, since the data that we want for Emerging Markets countries doesn't actually exist initially in the HTML, but is parsed from a JSON object and rendered in JS when the page is loaded in the browser. 

To get around this, I used `V8` which is a minimal and lightweight R interface for Google's open-source JavaScript engine. This allowed me to run the JS code and parse the resulting JSON, which I then used to pull the relevant countries. 

# tl;dr
* Lost `chromote` in favour of the lighter-weight `V8`