### PR TITLE
Expect `timestamp` input to be of format `YYYYMMDD`, and use this exact date when pulling indices

### DIFF
--- a/R/get_ishares_index_data.R
+++ b/R/get_ishares_index_data.R
@@ -5,8 +5,8 @@
 #' @param url A string containing the url of the desired iShares index data.
 #' @param name A string containing the name of the index.
 #' @param timestamp A string indicating the desired timestamp, by year and
-#'   quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for the first
-#'   day in the corresponding quarter.
+#'   quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
+#'   specified.
 #'
 #' @return A data.frame, containing the un-processed iShares data.
 #'

--- a/R/get_ishares_index_data.R
+++ b/R/get_ishares_index_data.R
@@ -4,7 +4,7 @@
 #'
 #' @param url A string containing the url of the desired iShares index data.
 #' @param name A string containing the name of the index.
-#' @param timestamp A string indicating the desired timestamp, by year, month
+#' @param as_of_date A string indicating the desired date, by year, month
 #'  and date, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
 #'  specified.
 #'
@@ -18,14 +18,14 @@
 #'     "251813/ishares-global-corporate-bond-ucits-etf/"
 #'   )
 #' name <- "iShares Global Corporate Bond UCITS ETF <USD (Distributing)>"
-#' timestamp <- "20211231"
+#' as_of_date <- "20211231"
 #'
-#' get_ishares_index_data(url, name, timestamp)
+#' get_ishares_index_data(url, name, as_of_date)
 #' }
 #'
 #' @export
 
-get_ishares_index_data <- function(url, name, timestamp) {
+get_ishares_index_data <- function(url, name, as_of_date) {
   page_url <- paste0(url, "/?siteEntryPassthrough=true")
   page_path <- curl::curl_download(page_url, tempfile())
 
@@ -34,9 +34,9 @@ get_ishares_index_data <- function(url, name, timestamp) {
     rvest::html_elements("#allHoldingsTable thead th") %>%
     rvest::html_text(trim = TRUE)
 
-  stopifnot(nchar(timestamp) == 8)
+  stopifnot(nchar(as_of_date) == 8)
 
-  data_url <- paste0(url, "/1506575576011.ajax?tab=all&fileType=json&asOfDate=", timestamp)
+  data_url <- paste0(url, "/1506575576011.ajax?tab=all&fileType=json&asOfDate=", as_of_date)
   data_path <- curl::curl_download(data_url, tempfile())
 
   raw_data <- suppressWarnings(
@@ -51,7 +51,7 @@ get_ishares_index_data <- function(url, name, timestamp) {
     dplyr::mutate(
       base_url = .env$url,
       index_name = .env$name,
-      timestamp = .env$timestamp
+      as_of_date = .env$as_of_date
     )
 }
 

--- a/R/get_ishares_index_data.R
+++ b/R/get_ishares_index_data.R
@@ -36,9 +36,7 @@ get_ishares_index_data <- function(url, name, timestamp) {
 
   stopifnot(nchar(timestamp) == 8)
 
-  as_of_date <- format(timestamp, "%Y%m%d")
-
-  data_url <- paste0(url, "/1506575576011.ajax?tab=all&fileType=json&asOfDate=", as_of_date)
+  data_url <- paste0(url, "/1506575576011.ajax?tab=all&fileType=json&asOfDate=", timestamp)
   data_path <- curl::curl_download(data_url, tempfile())
 
   raw_data <- suppressWarnings(
@@ -53,7 +51,7 @@ get_ishares_index_data <- function(url, name, timestamp) {
     dplyr::mutate(
       base_url = .env$url,
       index_name = .env$name,
-      timestamp = .env$as_of_date
+      timestamp = .env$timestamp
     )
 }
 

--- a/R/get_ishares_index_data.R
+++ b/R/get_ishares_index_data.R
@@ -4,9 +4,9 @@
 #'
 #' @param url A string containing the url of the desired iShares index data.
 #' @param name A string containing the name of the index.
-#' @param timestamp A string indicating the desired timestamp, by year and
-#'   quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
-#'   specified.
+#' @param timestamp A string indicating the desired timestamp, by year, month
+#'  and date, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
+#'  specified.
 #'
 #' @return A data.frame, containing the un-processed iShares data.
 #'

--- a/R/get_ishares_index_data.R
+++ b/R/get_ishares_index_data.R
@@ -34,8 +34,9 @@ get_ishares_index_data <- function(url, name, timestamp) {
     rvest::html_elements("#allHoldingsTable thead th") %>%
     rvest::html_text(trim = TRUE)
 
-  last_date_of_qrt <- lubridate::quarter(lubridate::as_date(timestamp), type = "date_last")
-  as_of_date <- format(last_date_of_qrt, "%Y%m%d")
+  stopifnot(nchar(timestamp) == 8)
+
+  as_of_date <- format(timestamp, "%Y%m%d")
 
   data_url <- paste0(url, "/1506575576011.ajax?tab=all&fileType=json&asOfDate=", as_of_date)
   data_path <- curl::curl_download(data_url, tempfile())

--- a/man/get_ishares_index_data.Rd
+++ b/man/get_ishares_index_data.Rd
@@ -11,8 +11,8 @@ get_ishares_index_data(url, name, timestamp)
 
 \item{name}{A string containing the name of the index.}
 
-\item{timestamp}{A string indicating the desired timestamp, by year and
-quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
+\item{timestamp}{A string indicating the desired timestamp, by year, month
+and date, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
 specified.}
 }
 \value{

--- a/man/get_ishares_index_data.Rd
+++ b/man/get_ishares_index_data.Rd
@@ -12,8 +12,8 @@ get_ishares_index_data(url, name, timestamp)
 \item{name}{A string containing the name of the index.}
 
 \item{timestamp}{A string indicating the desired timestamp, by year and
-quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for the first
-day in the corresponding quarter.}
+quarter, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
+specified.}
 }
 \value{
 A data.frame, containing the un-processed iShares data.

--- a/man/get_ishares_index_data.Rd
+++ b/man/get_ishares_index_data.Rd
@@ -4,14 +4,14 @@
 \alias{get_ishares_index_data}
 \title{Scrape index data from the iShares website}
 \usage{
-get_ishares_index_data(url, name, timestamp)
+get_ishares_index_data(url, name, as_of_date)
 }
 \arguments{
 \item{url}{A string containing the url of the desired iShares index data.}
 
 \item{name}{A string containing the name of the index.}
 
-\item{timestamp}{A string indicating the desired timestamp, by year, month
+\item{as_of_date}{A string indicating the desired as_of_date, by year, month
 and date, "YYYYMMDD" (e.g. "20201231"). Data will be scraped for date
 specified.}
 }
@@ -29,9 +29,9 @@ url <-
     "251813/ishares-global-corporate-bond-ucits-etf/"
   )
 name <- "iShares Global Corporate Bond UCITS ETF <USD (Distributing)>"
-timestamp <- "20211231"
+as_of_date <- "20211231"
 
-get_ishares_index_data(url, name, timestamp)
+get_ishares_index_data(url, name, as_of_date)
 }
 
 }


### PR DESCRIPTION
# Previously
This function had conflicting behavior to it's documentation. Documentation suggested that one should input a date formatted as `YYYYMMDD`, which would then be internally processed to find the first date of that quarter, which would then be used to scrape indices. 

The actual behavior is that the date would be forced to the last date of the quarter, which would be used to scrape indices. 

# Now
The function is simpler (but potentially more brittle). It simply uses whatever date you give it, and tries to find index data for that date. This means one has to be careful in deciding which date to input, however it allows the user to choose dates other than the last date of the quarter. This is important (right now), as it seems that there is no ishares data for "20221231", however data does exist for "20221230" (which seems like it should be close enough...)

Closes #21 