### PR TITLE
remove Vignette dependency from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,4 +60,3 @@ Config/testthat/edition: 3
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate
 URL: https://github.com/RMI-PACTA/pacta.data.scraping
 BugReports: https://github.com/RMI-PACTA/pacta.data.scraping/issues
-VignetteBuilder: knitr


### PR DESCRIPTION
It appears that R CMD check throws a Note now if a Vignette dependency is declared but there are no vignettes to render.